### PR TITLE
Update link Google JS style guide

### DIFF
--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -47,7 +47,7 @@ Coding conventions
 ------------------
 
 #### Javascript
-It is recommended to use the [google javascript style guide](http://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml) as a base for coding style.
+It is recommended to use the [google javascript style guide](https://google.github.io/styleguide/javascriptguide.xml) as a base for coding style.
 
 #### SCSS ( CSS )
 <% if (itcss) { -%>


### PR DESCRIPTION
Link to Google JS style guide is broken.